### PR TITLE
Mejorar la vista de Editar Usuario

### DIFF
--- a/database/migrations/2022_02_01_224659_mod_permissions_table_add_permission_category.php
+++ b/database/migrations/2022_02_01_224659_mod_permissions_table_add_permission_category.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ModPermissionsTableAddPermissionCategory extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('permissions', function (Blueprint $table){
+            $table->string('category')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('permissions', function (Blueprint $table){
+            $table->dropColumn('category');
+        });
+    }
+}

--- a/database/seeds/PermissionSeeder.php
+++ b/database/seeds/PermissionSeeder.php
@@ -14,310 +14,373 @@ class PermissionSeeder extends Seeder
     {
         $permission = Permission::create([
             'name' => 'Admin',
-            'description' => 'Administrador del sistema'
+            'description' => 'Administrador del sistema (Permiso muy poderoso)',
+            'category' => 'Administracion'
         ]);
         $permission = Permission::create([
             'name' => 'Developer',
-            'description' => 'Desarrollador (Solamente los Informáticos del Sistema Deberían tenerlo)'
+            'description' => 'Desarrollador (Solamente los Informáticos del Sistema Deberían tenerlo)',
+            'category' => 'Administracion'
         ]);
 
         $permission = Permission::create([
             'name' => 'Patient: create',
-            'description' => 'Permite crear un paciente (Funcionarios que hagan seguimiento principalmente)'
+            'description' => 'Permite crear un paciente (Funcionarios que hagan seguimiento principalmente)',
+            'category' => 'Paciente'
         ]);
         $permission = Permission::create([
             'name' => 'Patient: delete',
-            'description' => 'Permite eliminar un paciente (Sólo administradores)'
+            'description' => 'Permite eliminar un paciente (Sólo administradores)',
+            'category' => 'Paciente'
         ]);
         $permission = Permission::create([
             'name' => 'Patient: demographic edit',
-            'description' => 'Permite editar datos demográficos de un paciente (Para cualquiera que pueda editar los datos de un paciente)'
+            'description' => 'Permite editar datos demográficos de un paciente (Para cualquiera que pueda editar los datos de un paciente)',
+            'category' => 'Paciente'
         ]);
         $permission = Permission::create([
             'name' => 'Patient: edit',
-            'description' => 'Permite editar un paciente (Para cualquiera que pueda editar los datos de un paciente)'
+            'description' => 'Permite editar un paciente (Para cualquiera que pueda editar los datos de un paciente)',
+            'category' => 'Paciente'
         ]);
         $permission = Permission::create([
             'name' => 'Patient: epidemiologist',
-            'description' => 'Si uso por ahora'
+            'description' => 'Si uso por ahora',
+            'category' => 'Paciente'
         ]);
         $permission = Permission::create([
             'name' => 'Patient: georeferencing',
-            'description' => 'Permite visualizar georeferencia de pacientes positivos (global, de todo el sistema)'
+            'description' => 'Permite visualizar georeferencia de pacientes positivos (global, de todo el sistema)',
+            'category' => 'Paciente'
         ]);
         $permission = Permission::create([
             'name' => 'Patient: list',
-            'description' => 'Permite visualizar listado de pacientes'
+            'description' => 'Permite visualizar listado de pacientes',
+            'category' => 'Paciente'
         ]);
 
         $permission = Permission::create([
             'name' => 'Patient: show',
-            'description' => 'Permite ver datos de los pacientes sin poder modificar datos'
+            'description' => 'Permite ver datos de los pacientes sin poder modificar datos',
+            'category' => 'Paciente'
         ]);
 
 
         $permission = Permission::create([
             'name' => 'SanitaryResidence: admin',
-            'description' => 'Administrador Residencia Sanitaria'
+            'description' => 'Administrador Residencia Sanitaria',
+            'category' => 'Residencia Sanitaria'
         ]);
 
         $permission = Permission::create([
             'name' => 'SanitaryResidence: admission',
-            'description' => 'Usuario de SEREMI que autoriza ingreso a R.S.'
+            'description' => 'Usuario de SEREMI que autoriza ingreso a R.S.',
+            'category' => 'Residencia Sanitaria'
         ]);
 
         $permission = Permission::create([
             'name' => 'SanitaryResidence: survey',
-            'description' => 'Usuario que realiza encuesta para ver si Califica a R.S. en terreno (patient edit y patient list)'
+            'description' => 'Usuario que realiza encuesta para ver si Califica a R.S. en terreno (patient edit y patient list)',
+            'category' => 'Residencia Sanitaria'
         ]);
 
         $permission = Permission::create([
             'name' => 'SanitaryResidence: return booking',
-            'description' => 'Usuario que puede eliminar un egreso, y paciente se retorna a su booking'
+            'description' => 'Usuario que puede eliminar un egreso, y paciente se retorna a su booking',
+            'category' => 'Residencia Sanitaria'
         ]);
 
         $permission = Permission::create([
             'name' => 'SanitaryResidence: user',
-            'description' => 'Permite al usuario registrar en R.S.'
+            'description' => 'Permite al usuario registrar en R.S.',
+            'category' => 'Residencia Sanitaria'
         ]);
 
 
         $permission = Permission::create([
             'name' => 'SanitaryResidence: view',
-            'description' => 'Permite al usuario ver (no registrar) en R.S.'
+            'description' => 'Permite al usuario ver (no registrar) en R.S.',
+            'category' => 'Residencia Sanitaria'
         ]);
 
         $permission = Permission::create([
             'name' => 'SuspectCase: admission',
-            'description' => 'Permite crear muestra (tomadores de muestra)'
+            'description' => 'Permite crear muestra (tomadores de muestra)',
+            'category' => 'Caso Sospechoso'
         ]);
 
         $permission = Permission::create([
            'name' => 'SuspectCase: create',
-           'description' => '(No utilizar)'
+           'description' => '(No utilizar)',
+           'category' => 'Caso Sospechoso'
         ]);
 
         $permission = Permission::create([
             'name' => 'SuspectCase: delete',
-            'description' => 'Permite eliminar muestra (sólo para administradores)'
+            'description' => 'Permite eliminar muestra (sólo para administradores)',
+            'category' => 'Caso Sospechoso'
         ]);
 
         $permission = Permission::create([
             'name' => 'SuspectCase: edit',
-            'description' => 'Permite editar muestra (sólo para administradores)'
+            'description' => 'Permite editar muestra (sólo para administradores)',
+            'category' => 'Caso Sospechoso'
         ]);
 
         $permission = Permission::create([
             'name' => 'SuspectCase: file delete',
-            'description' => 'Permite eliminar el PDF de resultado de un examen (sólo para administradores)'
+            'description' => 'Permite eliminar el PDF de resultado de un examen (sólo para administradores)',
+            'category' => 'Caso Sospechoso'
         ]);
 
         $permission = Permission::create([
             'name' => 'SuspectCase: list',
-            'description' => 'Lista todos los exámenes por laboratorio, excluye aquellos que no han sido recepcionados'
+            'description' => 'Lista todos los exámenes por laboratorio, excluye aquellos que no han sido recepcionados',
+            'category' => 'Caso Sospechoso'
         ]);
 
         $permission = Permission::create([
             'name' => 'SuspectCase: reception',
-            'description' => 'Permite recepcionar muestra (para tecnólogos)'
+            'description' => 'Permite recepcionar muestra (para tecnólogos)',
+            'category' => 'Caso Sospechoso'
         ]);
 
         $permission = Permission::create([
             'name' => 'SuspectCase: tecnologo',
-            'description' => 'Permite agregar resultado de exámenes (para tecnólogos)'
+            'description' => 'Permite agregar resultado de exámenes (para tecnólogos)',
+            'category' => 'Caso Sospechoso'
         ]);
 
         $permission = Permission::create([
             'name' => 'SuspectCase: tecnologo edit',
-            'description' => 'Permite editar el resultado del exámen (para tecnólogos administradores)'
+            'description' => 'Permite editar el resultado del exámen (para tecnólogos administradores)',
+            'category' => 'Caso Sospechoso'
         ]);
 
         $permission = Permission::create([
             'name' => 'SuspectCase: own',
-            'description' => 'Lista todos los exámenes ingresados por un usuario y adicionalmente los que que han sido ingresados en el mismo establecimiento'
+            'description' => 'Lista todos los exámenes ingresados por un usuario y adicionalmente los que que han sido ingresados en el mismo establecimiento',
+            'category' => 'Caso Sospechoso'
         ]);
 
         $permission = Permission::create([
             'name' => 'SuspectCase: bulk load',
-            'description' => 'Permite acceso al formulario de carga masiva de pacientes, exámenes y resultados'
+            'description' => 'Permite acceso al formulario de carga masiva de pacientes, exámenes y resultados',
+            'category' => 'Caso Sospechoso'
         ]);
 
         $permission = Permission::create([
             'name' => 'SuspectCase: import results',
-            'description' => 'Permite acceso al formulario importar resultados de exámenes'
+            'description' => 'Permite acceso al formulario importar resultados de exámenes',
+            'category' => 'Caso Sospechoso'
         ]);
 
         $permission = Permission::create([
-            'name' => 'Lab: menu'
+            'name' => 'Lab: menu',
+            'category' => 'Laboratorio'
         ]);
 
         $permission = Permission::create([
             'name' => 'Report: positives',
-            'description' => 'Reporte de positivos (Global del sistema)'
+            'description' => 'Reporte de positivos (Global del sistema)',
+            'category' => 'Reporte'
         ]);
 
         $permission = Permission::create([
             'name' => 'Report: other',
-            'description' => 'Reporte de positivos antiguo (en desuso)'
+            'description' => 'Reporte de positivos antiguo (en desuso)',
+            'category' => 'Reporte'
         ]);
 
         $permission = Permission::create([
             'name' => 'Report: historical',
-            'description' => 'Reporte de positivos historico, con corte a las 21:00 (depende de CRON o tareas programadas)'
+            'description' => 'Reporte de positivos historico, con corte a las 21:00 (depende de CRON o tareas programadas)',
+            'category' => 'Reporte'
         ]);
 
         $permission = Permission::create([
             'name' => 'Report: exams with result',
-            'description' => 'Reporte de exámenes con resultados'
+            'description' => 'Reporte de exámenes con resultados',
+            'category' => 'Reporte'
         ]);
 
         $permission = Permission::create([
             'name' => 'Report: gestants',
-            'description' => 'Reporte de pacientes Gestantes.'
+            'description' => 'Reporte de pacientes Gestantes.',
+            'category' => 'Reporte'
         ]);
 
         $permission = Permission::create([
             'name' => 'Report: residences',
-            'description' => 'Reporte de "Consolidado de Booking" Total Ocupacional-Habitacional por R.S.'
+            'description' => 'Reporte de "Consolidado de Booking" Total Ocupacional-Habitacional por R.S.',
+            'category' => 'Reporte'
         ]);
 
         $permission = Permission::create([
             'name' => 'Report: positives by range',
-            'description' => 'Reporte Casos positivos por rango de fechas'
+            'description' => 'Reporte Casos positivos por rango de fechas',
+            'category' => 'Reporte'
         ]);
 
         $permission = Permission::create([
             'name' => 'Report: hospitalized',
-            'description' => 'Reporte de Listado de hospitalizados'
+            'description' => 'Reporte de Listado de hospitalizados',
+            'category' => 'Reporte'
         ]);
 
         $permission = Permission::create([
             'name' => 'Report: commune',
-            'description' => 'Reporte de positivos de mi comuna'
+            'description' => 'Reporte de positivos de mi comuna',
+            'category' => 'Reporte'
         ]);
 
         $permission = Permission::create([
             'name' => 'Report: deceased',
-            'description' => 'Reporte de pacientes fallecidos'
+            'description' => 'Reporte de pacientes fallecidos',
+            'category' => 'Reporte'
         ]);
 
         $permission = Permission::create([
             'name' => 'Report: user performance',
-            'description' => 'Reporte de eventos registrados por usuario'
+            'description' => 'Reporte de eventos registrados por usuario',
+            'category' => 'Reporte'
         ]);
 
         $permission = Permission::create([
             'name' => 'Report: more than two days',
-            'description' => 'Reporte de casos pendientes mayor a 48 horas'
+            'description' => 'Reporte de casos pendientes mayor a 48 horas',
+            'category' => 'Reporte'
         ]);
 
         $permission = Permission::create([
             'name' => 'Epp: list',
-            'description' => 'Movimientos de EPP'
+            'description' => 'Movimientos de EPP',
+            'category' => 'EPP'
         ]);
 
         $permission = Permission::create([
             'name' => 'Rapid Test: list',
-            'description' => 'Permite listar Test Rápido'
+            'description' => 'Permite listar Test Rápido',
+            'category' => 'Test Rápido'
         ]);
 
         $permission = Permission::create([
             'name' => 'Rapid Test: create',
-            'description' => 'Permite crear Test Rápido '
+            'description' => 'Permite crear Test Rápido ',
+            'category' => 'Test Rápido'
         ]);
 
         $permission = Permission::create([
             'name' => 'Rapid Test: edit',
-            'description' => 'Permite editar Test Rápido '
+            'description' => 'Permite editar Test Rápido ',
+            'category' => 'Test Rápido'
         ]);
 
         $permission = Permission::create([
             'name' => 'SocialTracing: seremi',
-            'description' => 'Permite acceder a los solicitudes de licencia SEREMI'
+            'description' => 'Permite acceder a los solicitudes de licencia SEREMI',
+            'category' => 'Trazabilidad'
         ]);
         $permission = Permission::create([
             'name' => 'SocialTracing: aps',
-            'description' => 'Permite acceder a los solicitudes de licencia APS'
+            'description' => 'Permite acceder a los solicitudes de licencia APS',
+            'category' => 'Trazabilidad'
         ]);
 
         $permission = Permission::create([
             'name' => 'Geo: communes',
-            'description' => 'Mapa de casos en seguimiento por comuna asociada a usuario'
+            'description' => 'Mapa de casos en seguimiento por comuna asociada a usuario',
+            'category' => 'Geo'
         ]);
 
         $permission = Permission::create([
             'name' => 'Geo: establishments',
-            'description' => 'Mapa de casos en seguimiento por establecimiento asociado a usuario'
+            'description' => 'Mapa de casos en seguimiento por establecimiento asociado a usuario',
+            'category' => 'Geo'
         ]);
 
         $permission = Permission::create([
             'name' => 'Report: hospitalized commune',
-            'description' => 'Reporte de Listado de hospitalizados por comunas asociadas a los establecimientos del usuario'
+            'description' => 'Reporte de Listado de hospitalizados por comunas asociadas a los establecimientos del usuario',
+            'category' => 'Reporte'
         ]);
 
         $permission = Permission::create([
             'name' => 'Patient: tracing',
-            'description' => 'Seguimiento a Paciente'
+            'description' => 'Seguimiento a Paciente',
+            'category' => 'Paciente'
         ]);
 
         $permission = Permission::create([
             'name' => 'Patient: tracing old',
-            'description' => 'Antiguo permiso de Tracing, ya no se utiliza'
+            'description' => 'Antiguo permiso de Tracing, ya no se utiliza',
+            'category' => 'Paciente'
         ]);
 
         $permission = Permission::create([
             'name' => 'Report: positive average by commune',
-            'description' => 'Reporte de positivos por comuna'
+            'description' => 'Reporte de positivos por comuna',
+            'category' => 'Reporte'
         ]);
 
         $permission = Permission::create([
             'name' => 'Report: cases with barcodes',
-            'description' => 'Listado de muestras por establecimiento y fecha de muestra con código de barra'
+            'description' => 'Listado de muestras por establecimiento y fecha de muestra con código de barra',
+            'category' => 'Reporte'
         ]);
 
         $permission = Permission::create([
             'name' => 'Report: rapid test',
-            'description' => 'Listado de Pacientes con Test Rápido'
+            'description' => 'Listado de Pacientes con Test Rápido',
+            'category' => 'Reporte'
         ]);
 
         $permission = Permission::create([
             'name' => 'NotContacted: create',
-            'description' => 'Crear nuevo paciente no contactado'
+            'description' => 'Crear nuevo paciente no contactado',
+            'category' => 'Contacto'
         ]);
 
         $permission = Permission::create([
             'name' => 'NotContacted: list',
-            'description' => 'Listar pacientes no contactados'
+            'description' => 'Listar pacientes no contactados',
+            'category' => 'Contacto'
         ]);
 
         $permission = Permission::create([
             'name' => 'NotContacted: show all',
-            'description' => 'Listar pacientes no contactados independiente de establecimiento asignado'
+            'description' => 'Listar pacientes no contactados independiente de establecimiento asignado',
+            'category' => 'Contacto'
         ]);
 
         $permission = Permission::create([
             'name' => 'NotContacted: delete',
-            'description' => 'Borrar paciente no contactado'
+            'description' => 'Borrar paciente no contactado',
+            'category' => 'Contacto'
         ]);
 
         $permission = Permission::create([
             'name' => 'SuspectCase: reception with barcode',
-            'description' => 'Habilita botón para recepcionar mediante código de barras'
+            'description' => 'Habilita botón para recepcionar mediante código de barras',
+            'category' => 'Caso Sospechoso'
         ]);
 
         $permission = Permission::create([
             'name' => 'SuspectCase: bulk load PNTM',
-            'description' => 'Carga masiva desde reporte PNTM'
+            'description' => 'Carga masiva desde reporte PNTM',
+            'category' => 'Caso Sospechoso'
         ]);
 
         $permission = Permission::create([
             'name' => 'SuspectCase: sequencing',
-            'description' => 'Módulo de secuenciación'
+            'description' => 'Módulo de secuenciación',
+            'category' => 'Caso Sospechoso'
         ]);
 
         $permission = Permission::create([
             'name' => 'SuspectCase: sequencing ISP',
-            'description' => 'Añade resultado ISP y Sospecha Local'
+            'description' => 'Añade resultado ISP y Sospecha Local',
+            'category' => 'Caso Sospechoso'
         ]);
 /*
         $users = User::all();

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -93,7 +93,7 @@
                 </fieldset>
                 <fieldset class="form-group col-12 col-md-6 ">
                     <button class="btn btn-danger float-md-right" type="submit" form="delete_form"
-                            onclick="return confirm('¿Está seguro que desea eliminar al usuario : {{$user->name}}? ' )">
+                            onclick="return confirm('¿Está seguro que desea eliminar al usuario {{$user->name}}?' )">
                         <i class="fas fa-user-slash"></i> Eliminar Usuario
                     </button>
                 </fieldset>
@@ -107,21 +107,32 @@
     <div class="form-row">
         <div class="col">
 
+            @php
+            $renderedCategories = array();
+            @endphp
 
-
-            <h5>Roles:</h5>
+            <h3>Permisos</h3>
             @foreach($permissions as $permission)
+
+            @if(!in_array($permission->category, $renderedCategories))
+            <h4>{{ $permission->category }}</h4>
+            @php
+            $renderedCategories[] = $permission->category;
+            @endphp
+            @endif
+
             <div class="form-check">
-                <input class="form-check-input" type="checkbox" name="permissions[]"
-                    value="{{ $permission->name }}" {{ ($user->hasPermissionTo($permission->name))?'checked':'' }}>
+                <input class="form-check-input" type="checkbox" name="permissions[]" onclick="if('{{ $permission->name }}' === 'Admin'|| '{{ $permission->name }}' === 'Developer' && this.checked) return confirm('¿Estás seguro de que quieres darle el rol {{$permission->name}} a {{$user->name}}?\n¡Este es un permiso peligroso!')"
+                    value="{{ $permission->name }}" {{ ($user->hasPermissionTo($permission->name))?'checked':'' }} >
                 <label class="form-check-label">
                     {{ $permission->name }}
                 </label>
+                <p class="text-muted">{{ $permission->description }}</p>
             </div>
             @endforeach
         </div>
         <!-- <div class="col">
-            <h5>Establecimientos:</h5>
+            <h3>Establecimientos:</h3>
             @foreach($establishments_user as $establishment_user)
               {{ $establishments_user }}
             @endforeach


### PR DESCRIPTION
Esta pull request contiene mejoras a la vista de **Editar Usuario** (`users/edit.blade.php`) y añade la columna `category` a `permissions` para mejorar la organización de estos. Igualmente se añadió una confirmación al asignar permisos/roles peligrosos (developer y admin).

![Confirmación añadida](https://user-images.githubusercontent.com/65878291/152170526-cbc06894-730b-4953-8afd-c2bdf452f695.png)


Nueva vista:
![Nueva vista Editar Usuario](https://user-images.githubusercontent.com/65878291/152169511-bf85f46f-9b74-4cfa-b37e-f09dd446228f.png)

Vista de la base de datos en phpMyAdmin con la nueva columna:
![Vista de la base de datos en phpMyAdmin](https://user-images.githubusercontent.com/65878291/152169828-0dae90cd-c9fb-4649-90cd-c01356a4e745.png)

Esta PR igual contiene el archivo de migración encargado de aplicar la nueva columna. (`2022_02_01_224659_mod_permissions_table_add_permission_category.php`)